### PR TITLE
[FIX] fail early with more informative error message when no slice was found

### DIFF
--- a/sd_get_image_specs.m
+++ b/sd_get_image_specs.m
@@ -70,6 +70,12 @@ xmm             = dims(X,1):dims(X,2):dims(X,3);
 ymm             = dims(Y,1):dims(Y,2):dims(Y,3);
 zmm             = slices(ismembertol(slices,settings.slice.disp_slices));
 [y, x]          = meshgrid(ymm,xmm');
+if isempty(zmm)
+    error(['Could not find any match to the requested slices.\n', ...
+           '\nRequested slices are:\n', repmat('%f, ', 1, numel(settings.slice.disp_slices)), ...
+           '\n\nPossible slices values are:\n', repmat('%f, ', 1, numel(slices))], ...
+               settings.slice.disp_slices, slices)
+end
 
 % Voxel and panel dimensions
 vdims           = [length(xmm),length(ymm),length(zmm)];


### PR DESCRIPTION
partially fixes #5 

it does not fix the issue but provide a "fail early solution" with more information on how to go about troubleshooting the issue.

```matlab
>> [settings, p] = sd_display(layers, settings);

Error using sd_get_image_specs (line 74)
Could not find any match to the requested slices.

Requested slices are:
-30.00, -27.00, -24.00, -21.00, -18.00, -15.00, -12.00, -9.00, -6.00, -3.00, 0.00, 3.00, 6.00, 9.00, 12.00, 15.00,
18.00, 21.00, 24.00, 27.00, 30.00, 33.00, 36.00, 39.00, 42.00, 45.00, 48.00,

Possible slices values are:
-78.50, -75.50, -72.50, -69.50, -66.50, -63.50, -60.50, -57.50, -54.50, -51.50, -48.50, -45.50, -42.50, -39.50,
-36.50, -33.50, -30.50, -27.50, -24.50, -21.50, -18.50, -15.50, -12.50, -9.50, -6.50, -3.50, -0.50, 2.50, 5.50,
8.50, 11.50, 14.50, 17.50, 20.50, 23.50, 26.50, 29.50, 32.50, 35.50, 38.50, 41.50, 44.50, 47.50, 50.50, 53.50,
56.50, 59.50, 62.50, 65.50, 68.50, 71.50, 74.50, 77.50, 80.50, 83.50, 86.50, 89.50, 92.50, 95.50, 98.50, 101.50,
104.50, 107.50, 110.50, 113.50,

Error in sd_display (line 40)
settings    = sd_get_image_specs(layers, settings);
```